### PR TITLE
Event calendar option

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,7 @@ If your theme supports widgets, the events calendar can also be added as a widge
 ## UK dates ##
 
 If the [CMB UK date field plugin](https://github.com/castlegateit/cgit-wp-cmb-ukdate) plugin is installed and you are using the Custom Meta Boxes plugin, the start and end dates will use that field type. If not, they will use the standard Unix date field.
+
+## License
+
+Released under the [MIT License](https://opensource.org/licenses/MIT). See [LICENSE](LICENSE) for details.

--- a/admin-options.php
+++ b/admin-options.php
@@ -13,7 +13,8 @@ class cgit_wp_events {
         'cgit_wp_events_post_type_support_author' => '',
         'cgit_wp_events_post_type_support_thumbnail' => '',
         'cgit_wp_events_post_type_support_comments' => '',
-        'cgit_wp_events_post_type_support_page-attributes' => ''
+        'cgit_wp_events_post_type_support_page-attributes' => '',
+        'cgit_wp_events_post_type_support_calendar-direct-url-to-event' => '1'
     );
 }
 
@@ -155,6 +156,17 @@ function cgit_wp_events_render_settings_page() {
                     <label>
                         <input type="checkbox" name="cgit_wp_events_post_type_support_page-attributes" value="1"<?php echo get_option('cgit_wp_events_post_type_support_page-attributes') ? ' checked="checked"' : ''; ?> />
                         Page attributes
+                    </label>
+                </td>
+            </tr>
+            
+            <tr>
+                <td>
+                    <label>
+                        <input type="checkbox" name="cgit_wp_events_post_type_support_calendar-direct-url-to-event" value="1"<?php echo get_option('cgit_wp_events_post_type_support_calendar-direct-url-to-event') ? ' checked="checked"' : ''; ?> />
+                        Direct URL to event on event calendar
+                        <br />
+                        <small>When enabled, the event calendar will display a direct link to an event when it is the only one on the day.</small>
                     </label>
                 </td>
             </tr>

--- a/calendar.php
+++ b/calendar.php
@@ -237,6 +237,9 @@ class Cgit_event_calendar {
         // Output variable
         $out = '';
 
+        // Check if the calendar should display a direct link to an event
+        $display_direct_link_to_event = $this->displayDirectLinkToEvent();
+
         // Loop through and output calendar days
         $i = 1;
         foreach ($this->getDays($this->year, $this->month) as $day) {
@@ -249,7 +252,7 @@ class Cgit_event_calendar {
             $out.= "<td class=\"" . $day['class'] . "\"><a";
 
             if ($day['events']) {
-                if (count($day['events']) == 1) {
+                if ($display_direct_link_to_event && count($day['events']) == 1) {
                     $link = reset($day['events']);
                     $link = $link['permalink'];
                 } else {
@@ -482,7 +485,8 @@ class Cgit_event_calendar {
             'year' => $this->year,
             'month' => $this->month,
             'days' => $this->getDays(),
-            'current' => $current->format($this->options['current_month'])
+            'current' => $current->format($this->options['current_month']),
+            'display_direct_link_to_event' => $this->displayDirectLinkToEvent(),
         );
     }
 
@@ -511,6 +515,27 @@ class Cgit_event_calendar {
         }
 
         return implode(' ', $return);
+    }
+
+    // -------------------------------------------------------------------------
+
+    /**
+     * Checks if the calendar should display a direct link to an event if it's the only one on the day.
+     *
+     * @author Castlgate IT <info@castlegateit.co.uk>
+     * @author Lamé Moatshe
+     *
+     * @return bool
+     */
+    private function displayDirectLinkToEvent()
+    {
+        $display_direct_link = get_option('cgit_wp_events_post_type_support_calendar-direct-url-to-event');
+
+        if($display_direct_link) {
+            return true;
+        }else {
+            return false;
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/cgit-wp-acf-events.php
+++ b/cgit-wp-acf-events.php
@@ -5,7 +5,7 @@ Plugin Name: Castlegate IT WP ACF Events
 Plugin URI: https://github.com/castlegateit/cgit-wp-acf-events/
 Description: A simple and easy to use events interface with complete developer
 control.
-Version: 1.7.3
+Version: 1.7.4
 Author: Castlegate IT
 Author URI: http://www.castlegateit.co.uk/
 */

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -11,6 +11,9 @@ jQuery(document).ready(function($) {
     function cgitEventsDrawCalendar(response) {
         var calendar = $('.cgit-events-calendar');
 
+        // Checks if the calendar should display a direct link to an event if it's the only one on a specific day
+        var display_direct_link_to_event = response.display_direct_link_to_event;
+
         // Trigger data loading event.
         calendar.trigger('cgit-wp-acf-events:data:loading');
 
@@ -35,7 +38,11 @@ jQuery(document).ready(function($) {
             //$(this).children('a').attr('href', response.days[index].link);
             if (response.days[index].events.length == 1) {
                 // If the day has events, give it a link
-                $(this).children('a').attr('href', response.days[index].events[0].permalink);
+                if(display_direct_link_to_event) {
+                    $(this).children('a').attr('href', response.days[index].events[0].permalink);
+                }else {
+                    $(this).children('a').attr('href', response.days[index].link);
+                }
             } else if (response.days[index].events.length > 1) {
                 $(this).children('a').attr('href', response.days[index].link);
             } else {


### PR DESCRIPTION
I've added an option that allows users to allow or disallow the calendar to set a direct URL to an event when it's the only one on a specific date.

When disabled, the event archive link will be used instead, this is the default option used when there are two or more events on a specific date.

This option will be enabled by default and can be managed on the event Options page.